### PR TITLE
feat: add emptyOutput and ignorePrefixes options to PatchOperation

### DIFF
--- a/src/main/java/codechicken/diffpatch/cli/DiffOperation.java
+++ b/src/main/java/codechicken/diffpatch/cli/DiffOperation.java
@@ -14,13 +14,13 @@ import net.covers1624.quack.util.SneakyUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.*;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Consumer;
 
 import static codechicken.diffpatch.util.LogLevel.*;
+import static codechicken.diffpatch.util.Utils.filterPrefixed;
 import static codechicken.diffpatch.util.Utils.indexChildren;
 
 /**
@@ -305,21 +305,6 @@ public class DiffOperation extends CliOperation<DiffOperation.DiffSummary> {
         log(this.summary ? INFO : DEBUG, "%s -> %s\n %d Added.\n %d Removed.", aName, bName, added, removed);
 
         return patchFile.toLines(autoHeader);
-    }
-
-    private static Set<String> filterPrefixed(Set<String> toFilter, String[] filters) {
-        if (filters.length == 0) return toFilter;
-
-        return FastStream.of(toFilter)
-                .filterNot(e -> {
-                    for (String s : filters) {
-                        if (e.startsWith(s)) {
-                            return true;
-                        }
-                    }
-                    return false;
-                })
-                .toSet();
     }
 
     public static class DiffSummary {

--- a/src/main/java/codechicken/diffpatch/util/Utils.java
+++ b/src/main/java/codechicken/diffpatch/util/Utils.java
@@ -1,5 +1,6 @@
 package codechicken.diffpatch.util;
 
+import net.covers1624.quack.collection.FastStream;
 import net.covers1624.quack.util.SneakyUtils;
 
 import java.io.IOException;
@@ -7,6 +8,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -42,5 +44,20 @@ public class Utils {
             return stream.filter(Files::isRegularFile)
                     .collect(Collectors.toMap(e -> stripStart('/', finalToIndex.relativize(e).toString().replace("\\", "/")), Function.identity()));
         }
+    }
+
+    public static Set<String> filterPrefixed(Set<String> toFilter, String[] filters) {
+        if (filters.length == 0) return toFilter;
+
+        return FastStream.of(toFilter)
+                .filterNot(e -> {
+                    for (String s : filters) {
+                        if (e.startsWith(s)) {
+                            return true;
+                        }
+                    }
+                    return false;
+                })
+                .toSet();
     }
 }


### PR DESCRIPTION
ignorePrefixes already exists on DiffOperation but is useful on patch too, to prevent copying of non modified files.
emptyOutput on DiffOperation allows working in scenarios where input = output, where you want to patch in place. its set to true by default (to replicate the current behavior) but can be toggled off.